### PR TITLE
Fixed importScripts()

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -44,7 +44,7 @@ if (!window.Worker || window.forceIframeWorker) {
 			w.importScripts = function () {
 				for (var i = 0; i < arguments.length; i++) {
 					var scriptEl = doc.createElement('script');
-					scriptEl.src = window.Worker.baseURI + script;
+					scriptEl.src = window.Worker.baseURI + arguments[i];
 					scriptEl.type = 'text/javascript';
 					doc.body.appendChild(scriptEl);
 				}


### PR DESCRIPTION
importScripts() currently imports the worker script instead of its arguments. This fixes it :-)
