### PR TITLE
IE fixes

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -89,7 +89,9 @@ if (!window.Worker || window.forceIframeWorker) {
 			function () {
 				worker._quere.push(
 					function () {
-						worker._iframeEl.contentWindow.onmessage({data:obj});
+						// IE8 throws an error if we call worker._iframeEl.contentWindow.onmessage() directly
+						var win = worker._iframeEl.contentWindow, onmessage = win.onmessage;
+						onmessage.call(win, {data:obj});
 					}
 				);
 			},


### PR DESCRIPTION
IE6-8 doesn't support `script.onload`, and so calls to `worker.postMessage()` were stuck in `worker._quere`. 48f57fa3ba5801f976a0e4c919accf4d447780fe adds support for `script.onreadystatechange` (basically copied from jQuery 1.7.2).

After this fix, IE8 kept throwing an error on `worker._iframeEl.contentWindow.onmessage({data:obj});`. For some reason 93518b601c2d4513391fcfb8fff1921adc614ac7 works, I'm not sure why :-)
