### PR TITLE
Typo: should be "use strict" not "use stricts"

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -1,4 +1,4 @@
-"use stricts";
+"use strict";
 
 if (!window.Worker || window.forceIframeWorker) {
 	if (window.Worker) window.nativeWorker = window.Worker;


### PR DESCRIPTION
I think there's a typo in worker.js!